### PR TITLE
Automated Windows 10 VM setup scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,32 @@
-# codetest
+# Mise en place d'une VM Windows 10 avec passthrough GPU
+
+Ce dépôt fournit des scripts de base pour déployer automatiquement une machine virtuelle Windows 10 orientée jeu vidéo. L'objectif est de partager la carte graphique AMD 6950 XT de l'hôte et d'assurer la compatibilité audio.
+
+## Prérequis
+- Hôte Linux avec KVM et IOMMU activé (Intel VT-d ou AMD-Vi).
+- `libvirt` et `virt-install` installés.
+- ISO d'installation de Windows 10.
+- Adresses PCI du GPU et de son périphérique audio.
+
+## Déploiement
+1. Personnaliser les variables dans `scripts/deploy_windows10_vm.sh` (chemin de l'ISO, adresse PCI du GPU, quantité de RAM, etc.).
+2. Exécuter le script en tant que root :
+   ```bash
+   sudo bash scripts/deploy_windows10_vm.sh
+   ```
+3. Suivre l'installation classique de Windows 10 dans la VM.
+4. Après installation, exécuter le script `guest/windows_setup.ps1` dans la VM pour installer Steam et Parsec et nettoyer certaines applications.
+
+## Notes supplémentaires
+- Vérifiez que votre système supporte bien le passthrough PCI (IOMMU actif, GPU réservé à la VM…).
+- Les performances et la latence dépendent fortement des pilotes et de la configuration réseau pour Parsec.
+- N'oubliez pas d'installer les pilotes GPU AMD adéquats dans la VM.
+
+## Tests
+Un script `scripts/test_scripts.sh` permet de vérifier rapidement la syntaxe des autres scripts du dépôt.
+
+```bash
+./scripts/test_scripts.sh
+```
+
+Il utilise `bash -n` et, si disponible, `pwsh` pour valider le script PowerShell.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Ce dépôt fournit des scripts de base pour déployer automatiquement une machin
 ## Notes supplémentaires
 - Vérifiez que votre système supporte bien le passthrough PCI (IOMMU actif, GPU réservé à la VM…).
 - Les performances et la latence dépendent fortement des pilotes et de la configuration réseau pour Parsec.
-- N'oubliez pas d'installer les pilotes GPU AMD adéquats dans la VM.
+- Le script `guest/windows_setup.ps1` installe aussi automatiquement les pilotes GPU AMD.
 
 ## Tests
 Un script `scripts/test_scripts.sh` permet de vérifier rapidement la syntaxe des autres scripts du dépôt.

--- a/guest/windows_setup.ps1
+++ b/guest/windows_setup.ps1
@@ -1,0 +1,31 @@
+# Script PowerShell à exécuter dans la VM pour installer Steam et Parsec
+# et désinstaller certaines applications Microsoft inutiles.
+
+# Installation de winget si nécessaire
+if (-not (Get-Command winget -ErrorAction SilentlyContinue)) {
+    Write-Output "Winget n'est pas disponible. Installez 'App Installer' depuis le Microsoft Store."
+}
+
+# Mettre à jour la base de données winget
+winget source update
+
+# Installer Steam et Parsec
+winget install -e --id Valve.Steam
+winget install -e --id Parsec.Parsec
+
+# Quelques réglages pour la latence
+reg add "HKCU\Software\Microsoft\GameBar" /v UseGameMode /t REG_DWORD /d 1 /f
+
+# Désinstallation de certaines applications par défaut
+$removeApps = @(
+    "Microsoft.BingWeather",
+    "Microsoft.Getstarted",
+    "Microsoft.ZuneMusic",
+    "Microsoft.ZuneVideo"
+)
+foreach ($app in $removeApps) {
+    Get-AppxPackage -Name $app -AllUsers | Remove-AppxPackage -ErrorAction SilentlyContinue
+}
+
+# Désactivation de la télémétrie basique
+reg add "HKLM\Software\Policies\Microsoft\Windows\DataCollection" /v AllowTelemetry /t REG_DWORD /d 0 /f

--- a/guest/windows_setup.ps1
+++ b/guest/windows_setup.ps1
@@ -13,6 +13,9 @@ winget source update
 winget install -e --id Valve.Steam
 winget install -e --id Parsec.Parsec
 
+# Installer les pilotes GPU AMD
+winget install -e --id AMD.AMDSoftwareCloudEdition
+
 # Quelques réglages pour la latence
 reg add "HKCU\Software\Microsoft\GameBar" /v UseGameMode /t REG_DWORD /d 1 /f
 

--- a/scripts/deploy_windows10_vm.sh
+++ b/scripts/deploy_windows10_vm.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Script de base pour créer une VM Windows 10 avec passthrough GPU/audio
+# Nécessite libvirt/virt-install et une machine hôte compatible IOMMU.
+
+set -e
+
+# Variables à personnaliser
+VM_NAME="win10-gaming"
+RAM_MB=8192
+VCPUS=4
+DISK_SIZE=60  # en Go
+ISO_PATH="/chemin/vers/windows10.iso"
+GPU_PCI="0000:03:00.0"     # Adresse PCI de la carte graphique 6950 XT
+GPU_AUDIO_PCI="0000:03:00.1" # Adresse PCI de l'audio HDMI de la carte
+DISK_PATH="/var/lib/libvirt/images/${VM_NAME}.qcow2"
+
+# Création du disque si absent
+if [ ! -f "$DISK_PATH" ]; then
+    qemu-img create -f qcow2 "$DISK_PATH" ${DISK_SIZE}G
+fi
+
+virt-install \ 
+  --name "$VM_NAME" \ 
+  --memory $RAM_MB \ 
+  --vcpus $VCPUS \ 
+  --cpu host,kvm=on \ 
+  --os-type windows \ 
+  --os-variant win10 \ 
+  --cdrom "$ISO_PATH" \ 
+  --disk path="$DISK_PATH",format=qcow2 \ 
+  --features hyperv_relaxed=on,hyperv_vapic=on,hyperv_spinlocks=on \ 
+  --host-device "$GPU_PCI" \ 
+  --host-device "$GPU_AUDIO_PCI" \ 
+  --soundhw hda \ 
+  --network network=default,model=virtio \ 
+  --graphics none \ 
+  --boot uefi \ 
+  --video none
+
+# Pour se connecter :
+# virsh start $VM_NAME
+# virsh console $VM_NAME
+# ou utiliser un client SPICE/VNC si défini.

--- a/scripts/test_scripts.sh
+++ b/scripts/test_scripts.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Vérifie la syntaxe des scripts Bash et PowerShell du dépôt.
+
+set -e
+
+echo "Checking deploy_windows10_vm.sh syntax..."
+bash -n "$(dirname "$0")/deploy_windows10_vm.sh"
+echo "OK"
+
+if command -v pwsh >/dev/null 2>&1; then
+    echo "Checking windows_setup.ps1 syntax..."
+    pwsh -NoProfile -Command "try { [System.Management.Automation.Language.Parser]::ParseFile('guest/windows_setup.ps1',[ref]null,[ref]null) | Out-Null } catch { exit 1 }"
+    echo "OK"
+else
+    echo "PowerShell n'est pas disponible, test ignoré pour windows_setup.ps1"
+fi


### PR DESCRIPTION
## Summary
- add script `deploy_windows10_vm.sh` to create a Windows 10 VM with GPU passthrough
- add `windows_setup.ps1` to install Steam and Parsec and remove some default apps
- expand `README` with instructions in French
- add `test_scripts.sh` to validate script syntax

## Testing
- `bash scripts/test_scripts.sh`
- `git status --short`
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_684a9a04a3a4832e9f70b929effeea9c