### PR TITLE
Add Windows-friendly test script

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,4 +29,6 @@ Discrete Device Assignment if `GPU_PCI_ID` is provided.
 ## Testing scripts
 
 Run `scripts/test_scripts.sh` to lint the shell scripts and validate the
-PowerShell syntax when a PowerShell executable is available.
+PowerShell syntax when a PowerShell executable is available. Windows users
+can run `scripts/test_scripts.ps1` in PowerShell to perform the same checks
+without a Bash environment.

--- a/scripts/test_scripts.ps1
+++ b/scripts/test_scripts.ps1
@@ -1,0 +1,21 @@
+Set-StrictMode -Version Latest
+
+# Lint shell scripts if bash is available
+$bash = Get-Command bash -ErrorAction SilentlyContinue
+if ($bash) {
+    Get-ChildItem -Path "scripts" -Filter "*.sh" -File | ForEach-Object {
+        & $bash.Path -n $_.FullName
+    }
+} else {
+    Write-Warning "bash not available; skipping shell script lint"
+}
+
+# Validate PowerShell script syntax
+$deployScript = Join-Path $PSScriptRoot 'deploy_windows10_vm.ps1'
+try {
+    [System.Management.Automation.Language.Parser]::ParseFile($deployScript,[ref]$null,[ref]$null) | Out-Null
+} catch {
+    Write-Error "Syntax error in deploy_windows10_vm.ps1"
+    exit 1
+}
+


### PR DESCRIPTION
## Summary
- add `test_scripts.ps1` for Windows users
- document new script in README

## Testing
- `./scripts/test_scripts.sh`

------
https://chatgpt.com/codex/tasks/task_e_684abd078580832e9ace6096d9826716